### PR TITLE
Fix a typo in README.md: Requirements.txt to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ source venv/bin/activate
 
 3. Download the dependencies using pip.
 ```
-pip install -r Requirements.txt
+pip install -r requirements.txt
 ```
 
 4. Start the app locally 


### PR DESCRIPTION
In the README.md file, in Instructions, it should be `pip install -r requirements.txt` instead of `pip install -r Requirements.txt`

Thanks for your work. The repo really helped me. 